### PR TITLE
Align pan flute loop with Orinoco Flo tempo

### DIFF
--- a/songs/coastline_panflute.js
+++ b/songs/coastline_panflute.js
@@ -1,0 +1,46 @@
+// "coastline panflute" @by openai
+// derived from coastline_jam.js
+samples('github:eddyflux/crate')
+setcps(.75)
+let chords = chord("<Bbm9 Fm9>/4").dict('ireal')
+stack(
+  stack( // DRUMS
+    s("bd").struct("<[x*<1 2> [~@3 x]] x>"),
+    s("~ [rim, sd:<2 3>]").room("<0 .2>"),
+    n("[0 <1 3>]*<2!3 4>").s("hh"),
+    s("rd:<1!3 2>*2").mask("<0 0 1 1>/16").gain(.5)
+  ).bank('crate')
+  .mask("<[0 1] 1 1 1>/16".early(.5))
+  , // CHORDS
+  chords.offset(-1).voicing().s("gm_epiano1:1")
+  .phaser(4).room(.5)
+  , // EXISTING MELODY
+  n("<0!3 1*2>").set(chords).mode("root:g2")
+  .voicing().s("gm_acoustic_bass"),
+  chords.n("[0 <4 3 <2 5>>*2](<3 5>,8)")
+  .anchor("D5").voicing()
+  .segment(4).clip(rand.range(.4,.8))
+  .room(.75).shape(.3).delay(.25)
+  .fm(sine.range(3,8).slow(8))
+  .lpf(sine.range(500,1000).slow(8)).lpq(5)
+  .rarely(ply("2")).chunk(4, fast(2))
+  .gain(perlin.range(.6, .9))
+  .mask("<0 1 1 0>/16")
+  , // PAN FLUTE MELODY ("Orinoco Flo" motif, in tempo)
+  chords.n("0 2 4 5 4 2 0 7 5 4 2 0")
+  .anchor("E6").voicing()
+  .s("gm_pan_flute")
+  .mode("major")
+  .room(.7).delay(.3)
+  .gain(1.2)
+  .pan(sine.range(-0.25,0.25).slow(2))
+  , // Supporting echo for fuller presence
+  chords.n("0 ~ 2 ~ 4 ~ 2 ~")
+  .anchor("E5").voicing()
+  .s("gm_pan_flute")
+  .mode("major")
+  .room(.6).delay(.35)
+  .gain(.9)
+  .lpf(1800)
+)
+.late("[0 .01]*4").late("[0 .01]*2").size(4)


### PR DESCRIPTION
## Summary
- Replace previous extended pan flute line with an "Orinoco Flo" style melody that loops in a single cycle and matches the track's tempo

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e4d5f243c832dbe9a00558b59d6a7